### PR TITLE
Add upload artifact to action to pipeline

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       deploy_tag:
-        required: true
+        required: false
         type: string
         default: ''
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -48,3 +48,11 @@ jobs:
       run:   gh release upload --clobber ${{ inputs.deploy_tag }} (get-item *.msi)
       env:
         GH_TOKEN: ${{ github.token }}
+
+    # Upload as workflow artifact if deploy_tag is empty
+    - name: Upload as Artifact
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_tag == '' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: PdfScribeInstaller
+        path: ./PdfScribeInstall/bin/x64/Release/en-us/*.msi


### PR DESCRIPTION
Now you can run the workflow without a deploy tag, then the artifact will be uploaded to the action itself.

Ways to run this workflow is: 

1. Create a release. It will automatically run and attach the artifacts to any published release.
2. Run the workflow manually with a release tag. It will attach an artifact to the release with the same tag. (Or potentially create a release if it does not exists. Unsure.)
3. Run the workflow manually without a deploy tag which will attach the build artifact to the action itself for download.